### PR TITLE
Customize update required screen texts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    dataBinding {
+        enabled  = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/everli/uppysample/Application.kt
+++ b/app/src/main/java/com/everli/uppysample/Application.kt
@@ -10,10 +10,7 @@ class Application : Application() {
 
         Uppy.init(
             "https://www.example.com/api/",
-            "example-slug",
-            forcedTitle = R.string.forcedTitle,
-            title = R.string.title,
-            message = R.string.message
+            "example-slug"
         )
 
         // if you want to track installations, provide a unique device id

--- a/app/src/main/java/com/everli/uppysample/Application.kt
+++ b/app/src/main/java/com/everli/uppysample/Application.kt
@@ -8,7 +8,14 @@ class Application : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        Uppy.init("https://www.example.com/api/", "example-slug")
+        Uppy.init(
+            "https://www.example.com/api/",
+            "example-slug",
+            forcedTitle = R.string.forcedTitle,
+            title = R.string.title,
+            message = R.string.message
+        )
+
         // if you want to track installations, provide a unique device id
         //  Uppy.init("https://www.example.com/api/", "example-slug", "your-device-id")
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">UppySample</string>
+    <string name="message">Sample update required text Description</string>
+    <string name="title">Sample update required title</string>
+    <string name="forcedTitle">Forced update required title</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,8 @@
     <string name="message">Sample update required text Description</string>
     <string name="title">Sample update required title</string>
     <string name="forcedTitle">Forced update required title</string>
+
+    <string name="forced_newer_version_available">Custom forced update required title</string>
+    <string name="dialog_update_available">Custom title</string>
+    <string name="dialog_new_version_available">Custom description a new version is available, would you like to update?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,9 @@
     <string name="title">Sample update required title</string>
     <string name="forcedTitle">Forced update required title</string>
 
-    <string name="forced_newer_version_available">Custom forced update required title</string>
-    <string name="dialog_update_available">Custom title</string>
-    <string name="dialog_new_version_available">Custom description a new version is available, would you like to update?</string>
+    <string name="uppy_forced_newer_version_available">Ops, la versione dell\'app è vecchia. Aggiornala per continuare ad utilizzarla correttamente!</string>
+    <string name="uppy_update_dialog_title">Update Available</string>
+    <string name="uppy_update_dialog_message">Una nuova versione della shopper app è disponibile. vuoi scaricarla?</string>
+    <string name="uppy_update_button">Aggiorna</string>
+    <string name="uppy_update_dialog_later">Dopo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,9 +4,12 @@
     <string name="title">Sample update required title</string>
     <string name="forcedTitle">Forced update required title</string>
 
-    <string name="uppy_forced_newer_version_available">Ops, la versione dell\'app è vecchia. Aggiornala per continuare ad utilizzarla correttamente!</string>
-    <string name="uppy_update_dialog_title">Update Available</string>
-    <string name="uppy_update_dialog_message">Una nuova versione della shopper app è disponibile. vuoi scaricarla?</string>
-    <string name="uppy_update_button">Aggiorna</string>
-    <string name="uppy_update_dialog_later">Dopo</string>
+<!--  Bellow here we can find some examples about how to customize the texts in your app,
+        just place any of these strings in you app's strings.xml   -->
+    
+<!--    <string name="uppy_forced_newer_version_available">Ops, la versione dell\'app è vecchia. Aggiornala per continuare ad utilizzarla correttamente!</string>-->
+<!--    <string name="uppy_update_dialog_title">Update Available</string>-->
+<!--    <string name="uppy_update_dialog_message">Una nuova versione della shopper app è disponibile. vuoi scaricarla?</string>-->
+<!--    <string name="uppy_update_button">Aggiorna</string>-->
+<!--    <string name="uppy_update_dialog_later">Dopo</string>-->
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/uppy/build.gradle
+++ b/uppy/build.gradle
@@ -24,6 +24,11 @@ android {
         }
     }
 
+    buildFeatures.dataBinding = true
+
+    viewBinding {
+        enabled = true
+    }
 }
 
 dependencies {

--- a/uppy/build.gradle
+++ b/uppy/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 29
         versionCode 4
-        versionName "0.0.4"
+        versionName "0.0.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/uppy/src/main/java/com/everli/uppy/ShowUpdateListener.kt
+++ b/uppy/src/main/java/com/everli/uppy/ShowUpdateListener.kt
@@ -12,10 +12,7 @@ import java.lang.ref.WeakReference
 class ShowUpdateListener(
     private val updateCheck: UpdateCheck,
     lifecycle: Lifecycle,
-    context: Context,
-    private val title: Int?,
-    private val message: Int?,
-    private val forcedTitle: Int?
+    context: Context
 ) : UpdateListener, LifecycleObserver {
 
     private val lifecycleRef: WeakReference<Lifecycle> = WeakReference(lifecycle)
@@ -41,15 +38,12 @@ class ShowUpdateListener(
         if (!updateCheck.forced) {
             UpdateDialog(
                 it,
-                updateCheck.downloadUrl,
-                title,
-                message
+                updateCheck.downloadUrl
             ).show()
         } else {
             val intent = ForcedUpdateActivity.newIntent(
                 it,
-                updateCheck.downloadUrl,
-                forcedTitle
+                updateCheck.downloadUrl
             )
 
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/uppy/src/main/java/com/everli/uppy/ShowUpdateListener.kt
+++ b/uppy/src/main/java/com/everli/uppy/ShowUpdateListener.kt
@@ -12,7 +12,10 @@ import java.lang.ref.WeakReference
 class ShowUpdateListener(
     private val updateCheck: UpdateCheck,
     lifecycle: Lifecycle,
-    context: Context
+    context: Context,
+    private val title: Int?,
+    private val message: Int?,
+    private val forcedTitle: Int?
 ) : UpdateListener, LifecycleObserver {
 
     private val lifecycleRef: WeakReference<Lifecycle> = WeakReference(lifecycle)
@@ -20,6 +23,7 @@ class ShowUpdateListener(
 
     override fun showUpdates() {
         val lifecycle = lifecycleRef.get()
+
         if (lifecycle?.currentState?.isAtLeast(Lifecycle.State.RESUMED) == true) {
             showUpdateResult()
         } else {
@@ -33,16 +37,24 @@ class ShowUpdateListener(
         lifecycleRef.get()?.removeObserver(this)
     }
 
-    private fun showUpdateResult() {
-        val context = contextRef.get()
-        context?.let {
-            if (!updateCheck.forced) {
-                UpdateDialog(context, updateCheck.downloadUrl).show()
-            } else {
-                val intent = ForcedUpdateActivity.newIntent(context, updateCheck.downloadUrl)
-                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
-                context.startActivity(intent)
-            }
+    private fun showUpdateResult() = contextRef.get()?.let {
+        if (!updateCheck.forced) {
+            UpdateDialog(
+                it,
+                updateCheck.downloadUrl,
+                title,
+                message
+            ).show()
+        } else {
+            val intent = ForcedUpdateActivity.newIntent(
+                it,
+                updateCheck.downloadUrl,
+                forcedTitle
+            )
+
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+
+            it.startActivity(intent)
         }
     }
 }

--- a/uppy/src/main/java/com/everli/uppy/UpdateDialog.kt
+++ b/uppy/src/main/java/com/everli/uppy/UpdateDialog.kt
@@ -6,19 +6,12 @@ import it.everli.uppy.R
 
 class UpdateDialog(
     context: Context,
-    private val downloadUrl: String,
-    private val title: Int?,
-    private val message: Int?
+    private val downloadUrl: String
 ) : AlertDialog(context) {
 
     init {
-        title?.let {
-            setTitle(it)
-        } ?: setTitle(R.string.dialog_update_available)
-
-        message?.let {
-            setMessage(context.getString(it))
-        } ?: setMessage(context.getString(R.string.dialog_new_version_available))
+        setTitle(R.string.dialog_update_available)
+        setMessage(context.getString(R.string.dialog_new_version_available))
 
         setButton(BUTTON_POSITIVE, context.getString(R.string.update)) { _, _ ->
             BrowserDownloadManager(context).startDownload(downloadUrl)

--- a/uppy/src/main/java/com/everli/uppy/UpdateDialog.kt
+++ b/uppy/src/main/java/com/everli/uppy/UpdateDialog.kt
@@ -4,16 +4,30 @@ import android.app.AlertDialog
 import android.content.Context
 import it.everli.uppy.R
 
-class UpdateDialog(context: Context, private val downloadUrl: String) : AlertDialog(context) {
+class UpdateDialog(
+    context: Context,
+    private val downloadUrl: String,
+    private val title: Int?,
+    private val message: Int?
+) : AlertDialog(context) {
+
     init {
-        setTitle(R.string.dialog_update_available)
-        setMessage(context.getString(R.string.dialog_new_version_available))
+        title?.let {
+            setTitle(it)
+        } ?: setTitle(R.string.dialog_update_available)
+
+        message?.let {
+            setMessage(context.getString(it))
+        } ?: setMessage(context.getString(R.string.dialog_new_version_available))
+
         setButton(BUTTON_POSITIVE, context.getString(R.string.update)) { _, _ ->
             BrowserDownloadManager(context).startDownload(downloadUrl)
         }
+
         setButton(BUTTON_NEUTRAL, context.getString(R.string.dialog_later)) { _, _ ->
             cancel()
         }
+
         setCancelable(false)
     }
 }

--- a/uppy/src/main/java/com/everli/uppy/UpdateDialog.kt
+++ b/uppy/src/main/java/com/everli/uppy/UpdateDialog.kt
@@ -10,14 +10,14 @@ class UpdateDialog(
 ) : AlertDialog(context) {
 
     init {
-        setTitle(R.string.dialog_update_available)
-        setMessage(context.getString(R.string.dialog_new_version_available))
+        setTitle(R.string.uppy_update_dialog_title)
+        setMessage(context.getString(R.string.uppy_update_dialog_message))
 
-        setButton(BUTTON_POSITIVE, context.getString(R.string.update)) { _, _ ->
+        setButton(BUTTON_POSITIVE, context.getString(R.string.uppy_update_button)) { _, _ ->
             BrowserDownloadManager(context).startDownload(downloadUrl)
         }
 
-        setButton(BUTTON_NEUTRAL, context.getString(R.string.dialog_later)) { _, _ ->
+        setButton(BUTTON_NEUTRAL, context.getString(R.string.uppy_update_dialog_later)) { _, _ ->
             cancel()
         }
 

--- a/uppy/src/main/java/com/everli/uppy/Uppy.kt
+++ b/uppy/src/main/java/com/everli/uppy/Uppy.kt
@@ -32,24 +32,15 @@ object Uppy : UppySdk {
     private lateinit var uppyService: UppyService
 
     private var deviceId: String? = null
-    private var forcedTitle: Int? = null
-    private var title: Int? = null
-    private var message: Int? = null
 
     fun init(
         serverUrl: String,
         slug: String,
-        deviceId: String? = null,
-        forcedTitle: Int? = null,
-        title: Int? = null,
-        message: Int? = null
+        deviceId: String? = null
     ) {
         Uppy.serverUrl = serverUrl
         Uppy.slug = slug
         Uppy.deviceId = deviceId
-        Uppy.title = title
-        Uppy.message = message
-        Uppy.forcedTitle = forcedTitle
 
         val logging = HttpLoggingInterceptor()
         val level = if (BuildConfig.DEBUG) {
@@ -103,10 +94,7 @@ object Uppy : UppySdk {
                             ShowUpdateListener(
                                 it,
                                 lifecycleOwner.lifecycle,
-                                context,
-                                title,
-                                message,
-                                forcedTitle
+                                context
                             ).showUpdates()
                         }
                     }

--- a/uppy/src/main/java/com/everli/uppy/Uppy.kt
+++ b/uppy/src/main/java/com/everli/uppy/Uppy.kt
@@ -32,11 +32,24 @@ object Uppy : UppySdk {
     private lateinit var uppyService: UppyService
 
     private var deviceId: String? = null
+    private var forcedTitle: Int? = null
+    private var title: Int? = null
+    private var message: Int? = null
 
-    fun init(serverUrl: String, slug: String, deviceId: String? = null) {
+    fun init(
+        serverUrl: String,
+        slug: String,
+        deviceId: String? = null,
+        forcedTitle: Int? = null,
+        title: Int? = null,
+        message: Int? = null
+    ) {
         Uppy.serverUrl = serverUrl
         Uppy.slug = slug
         Uppy.deviceId = deviceId
+        Uppy.title = title
+        Uppy.message = message
+        Uppy.forcedTitle = forcedTitle
 
         val logging = HttpLoggingInterceptor()
         val level = if (BuildConfig.DEBUG) {
@@ -44,6 +57,7 @@ object Uppy : UppySdk {
         } else {
             HttpLoggingInterceptor.Level.NONE
         }
+
         logging.level = level
 
         client = OkHttpClient.Builder()
@@ -69,7 +83,8 @@ object Uppy : UppySdk {
     override fun checkForUpdates(
         context: Context, lifecycleOwner: LifecycleOwner
     ) {
-        val updateRequest = CheckForUpdatesRequest(context.packageManager.getCurrentAppVersion(context), deviceId)
+        val updateRequest =
+            CheckForUpdatesRequest(context.packageManager.getCurrentAppVersion(context), deviceId)
 
         uppyService
             .checkLatestVersion(slug, updateRequest)
@@ -88,7 +103,10 @@ object Uppy : UppySdk {
                             ShowUpdateListener(
                                 it,
                                 lifecycleOwner.lifecycle,
-                                context
+                                context,
+                                title,
+                                message,
+                                forcedTitle
                             ).showUpdates()
                         }
                     }
@@ -101,7 +119,8 @@ object Uppy : UppySdk {
         lifecycleOwner: LifecycleOwner,
         callback: UpdateCallback
     ) {
-        val updateRequest = CheckForUpdatesRequest(context.packageManager.getCurrentAppVersion(context), deviceId)
+        val updateRequest =
+            CheckForUpdatesRequest(context.packageManager.getCurrentAppVersion(context), deviceId)
 
         uppyService
             .checkLatestVersion(slug, updateRequest)

--- a/uppy/src/main/java/com/everli/uppy/update/ForcedUpdateActivity.kt
+++ b/uppy/src/main/java/com/everli/uppy/update/ForcedUpdateActivity.kt
@@ -52,7 +52,7 @@ class ForcedUpdateActivity : AppCompatActivity() {
         findViewById<Button>(R.id.update).setOnClickListener {
             downloadUrl?.let {
                 BrowserDownloadManager(this).startDownload(it)
-            } ?: Toast.makeText(this, R.string.forced_update_url_empty, Toast.LENGTH_LONG).show()
+            } ?: Toast.makeText(this, R.string.uppy_forced_update_url_empty, Toast.LENGTH_LONG).show()
         }
     }
 }

--- a/uppy/src/main/java/com/everli/uppy/update/ForcedUpdateActivity.kt
+++ b/uppy/src/main/java/com/everli/uppy/update/ForcedUpdateActivity.kt
@@ -14,16 +14,13 @@ class ForcedUpdateActivity : AppCompatActivity() {
 
     companion object {
         private const val EXTRA_DOWNLOAD_URL = "ForcedUpdateActivity.Extra.downloadUrl"
-        private const val EXTRA_TITLE = "ForcedUpdateActivity.Extra.title"
 
         @JvmStatic
-        fun newIntent(context: Context, downloadUrl: String, forcedTitle: Int?): Intent {
+        fun newIntent(context: Context, downloadUrl: String): Intent {
             val intent = Intent(context, ForcedUpdateActivity::class.java)
             val extras = Bundle()
 
             extras.putString(EXTRA_DOWNLOAD_URL, downloadUrl)
-
-            forcedTitle?.let { extras.putInt(EXTRA_TITLE, it) }
 
             intent.putExtras(extras)
 
@@ -34,7 +31,6 @@ class ForcedUpdateActivity : AppCompatActivity() {
     private lateinit var binding: ActivityForcedUpdateBinding
 
     private var downloadUrl: String? = null
-    private var titleResourceId: Int = -1
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,11 +39,6 @@ class ForcedUpdateActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         downloadUrl = intent.getStringExtra(EXTRA_DOWNLOAD_URL)
-        titleResourceId = intent.getIntExtra(EXTRA_TITLE, -1)
-
-        if (titleResourceId > 0) {
-            binding.message.text = getString(titleResourceId)
-        }
 
         setListeners()
     }

--- a/uppy/src/main/java/com/everli/uppy/update/ForcedUpdateActivity.kt
+++ b/uppy/src/main/java/com/everli/uppy/update/ForcedUpdateActivity.kt
@@ -8,31 +8,46 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.everli.uppy.BrowserDownloadManager
 import it.everli.uppy.R
+import it.everli.uppy.databinding.ActivityForcedUpdateBinding
 
 class ForcedUpdateActivity : AppCompatActivity() {
 
     companion object {
         private const val EXTRA_DOWNLOAD_URL = "ForcedUpdateActivity.Extra.downloadUrl"
+        private const val EXTRA_TITLE = "ForcedUpdateActivity.Extra.title"
 
         @JvmStatic
-        fun newIntent(context: Context, downloadUrl: String): Intent {
+        fun newIntent(context: Context, downloadUrl: String, forcedTitle: Int?): Intent {
             val intent = Intent(context, ForcedUpdateActivity::class.java)
             val extras = Bundle()
 
             extras.putString(EXTRA_DOWNLOAD_URL, downloadUrl)
+
+            forcedTitle?.let { extras.putInt(EXTRA_TITLE, it) }
+
             intent.putExtras(extras)
 
             return intent
         }
     }
 
+    private lateinit var binding: ActivityForcedUpdateBinding
+
     private var downloadUrl: String? = null
+    private var titleResourceId: Int = -1
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_forced_update)
+        binding = ActivityForcedUpdateBinding.inflate(layoutInflater)
+
+        setContentView(binding.root)
 
         downloadUrl = intent.getStringExtra(EXTRA_DOWNLOAD_URL)
+        titleResourceId = intent.getIntExtra(EXTRA_TITLE, -1)
+
+        if (titleResourceId > 0) {
+            binding.message.text = getString(titleResourceId)
+        }
 
         setListeners()
     }

--- a/uppy/src/main/res/layout/activity_forced_update.xml
+++ b/uppy/src/main/res/layout/activity_forced_update.xml
@@ -13,14 +13,16 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_marginTop="40dp"
-            android:text="@string/forced_newer_version_available" />
+            android:textAlignment="center"
+            android:layout_margin="40dp"
+            android:text="@string/uppy_forced_newer_version_available" />
 
         <Button
             android:id="@+id/update"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="@string/update" />
+            android:paddingHorizontal="24dp"
+            android:text="@string/uppy_update_button" />
     </FrameLayout>
 </layout>

--- a/uppy/src/main/res/layout/activity_forced_update.xml
+++ b/uppy/src/main/res/layout/activity_forced_update.xml
@@ -1,22 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/transparent_white"
-    tools:context="com.everli.uppy.update.ForcedUpdateActivity">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="40dp"
-        android:text="@string/forced_newer_version_available" />
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/transparent_white"
+        tools:context="com.everli.uppy.update.ForcedUpdateActivity">
 
-    <Button
-        android:id="@+id/update"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="@string/update" />
-</FrameLayout>
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="40dp"
+            android:text="@string/forced_newer_version_available" />
+
+        <Button
+            android:id="@+id/update"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/update" />
+    </FrameLayout>
+</layout>

--- a/uppy/src/main/res/values/strings.xml
+++ b/uppy/src/main/res/values/strings.xml
@@ -1,14 +1,14 @@
 <resources>
     <!-- Common -->
-    <string name="update">Update</string>
+    <string name="uppy_update_button">Update</string>
 
     <!-- Update Dialog -->
-    <string name="dialog_update_available">Update Available</string>
-    <string name="dialog_new_version_available">A new version is available, would you like to update?</string>
-    <string name="dialog_later">Later</string>
+    <string name="uppy_update_dialog_title">Update Available</string>
+    <string name="uppy_update_dialog_message">A new version is available, would you like to update?</string>
+    <string name="uppy_update_dialog_later">Later</string>
 
     <!-- Forced Update Activity -->
-    <string name="forced_update_url_empty">Update URL empty</string>
-    <string name="forced_newer_version_available">A newer version of this app is available</string>
+    <string name="uppy_forced_update_url_empty">Update URL empty</string>
+    <string name="uppy_forced_newer_version_available">A newer version of this app is available</string>
 
 </resources>


### PR DESCRIPTION
We have added the feature to enable handling over some string resource ids to the UppyService so the texts of the forced update activity and/or the pending update dialog can be customized